### PR TITLE
Rename API resource from search to subjects

### DIFF
--- a/src/components/Home/Hero.jsx
+++ b/src/components/Home/Hero.jsx
@@ -20,7 +20,7 @@ const Hero = () => {
 
     if (value) {
       try {
-        const response = await axios.get(`${ACV_API_BASE_URL}/Prod/search/`, {
+        const response = await axios.get(`${ACV_API_BASE_URL}/Prod/subjects/`, {
           params: { q: value },
         });
 


### PR DESCRIPTION
仕様変更に伴い、講義取得APIのメソッド名をsearchからsubjectsに変更